### PR TITLE
Pep8 ify

### DIFF
--- a/05-files-from-grid.md
+++ b/05-files-from-grid.md
@@ -49,7 +49,8 @@ Since those tuples tend to be quite large, you might want to use your AFS work d
 If you want to obtain all the files, you can copy and paste the list of file names from the file you got from the bookkeeping and paste them into the following python script for convenience.
 
 ```python
-FILES = []  # Your list of file names here
+# Your list of file names here
+FILES = []
 
 if __name__ == '__main__':
     from subprocess import call
@@ -61,9 +62,9 @@ if __name__ == '__main__':
 
     files = FILES[:n_files]
     for f in files:
-        print('Getting file %s.' % f)
-        call('dirac-dms-get-file %s' % f, shell=True)
-    print('Done getting %d files.' % n_files)
+        print('Getting file {0}.'.format(f))
+        call('dirac-dms-get-file {0}'.format(f), shell=True)
+    print('Done getting {0} files.'.format(n_files))
 ```
 
 Save it as `getEvents.py` and use it via `python getEvents.py [n]`. If you specify `n`, the script will only get the first n files from the grid.

--- a/05-interactive-dst.md
+++ b/05-interactive-dst.md
@@ -31,16 +31,20 @@ import sys
 
 import GaudiPython as GP
 from GaudiConf import IOHelper
-from Configurables import LHCbApp, ApplicationMgr, DataOnDemandSvc
-from Configurables import DecodeRawEvent
-from Configurables import CondDB
-from Configurables import DaVinci
+from Configurables import (
+  LHCbApp,
+  ApplicationMgr,
+  DataOnDemandSvc,
+  DecodeRawEvent,
+  CondDB,
+  DaVinci
+)
 
 
 appConf = ApplicationMgr()
 
 dv = DaVinci()
-dv.DataType = "2012"
+dv.DataType = '2012'
 
 dre = DecodeRawEvent()
 dre.DataOnDemand = True
@@ -99,7 +103,7 @@ def nodes(evt, node=None):
         for l in evt.leaves(node):
             # skip a location that takes forever to load
             # XXX How to detect these automatically??
-            if "Swum" in l.identifier():
+            if 'Swum' in l.identifier():
                 continue
 
             temp = evt[l.identifier()]
@@ -134,13 +138,13 @@ def advance(decision):
     while True:
         appMgr.run(1)
 
-        if not evt["/Event/Rec/Header"]:
-            print "Reached end of input files"
+        if not evt['/Event/Rec/Header']:
+            print 'Reached end of input files'
             break
 
         n += 1
         dec=evt['/Event/Strip/Phys/DecReports']
-        if dec.hasDecisionName("Stripping%sDecision"%decision):
+        if dec.hasDecisionName('Stripping{0}Decision".format(decision)):
             break
 
     return n
@@ -186,6 +190,8 @@ There is a useful tool for printing out decay trees, which you can
 pass the top level particle to and it will print out the daughters etc:
 
 ```
-print_decay = appMgr.toolsvc().create('PrintDecayTreeTool', interface="IPrintDecayTreeTool")
+print_decay = appMgr.toolsvc().create(
+  'PrintDecayTreeTool', interface='IPrintDecayTreeTool'
+)
 print_decay.printTree(cands[0])
 ```

--- a/06-building-decays.md
+++ b/06-building-decays.md
@@ -63,29 +63,29 @@ This algorithm performs the combinatorics for us according to a given decay desc
 
  - `DaughtersCuts` is a dictionary that maps each child particle type to a LoKi particle functor that determines if that particular particle satisfies our selection criteria. Optionally, one can specify also a `Preambulo` property that allows us to make imports, preprocess functors, etc (more on this in the [LoKi functors](https://lhcb.github.io/first-analysis-steps/06-loki-functors.html) lesson). For example:
 
-```python
-d0_daughters = {
-  'pi-': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)',
-  'K+': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)'
-}
-```
+    ```python
+    d0_daughters = {
+      'pi-': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)',
+      'K+': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)'
+    }
+    ```
 
  - `CombinationCut` is a particle array LoKi functor (note the `A` prefix, see more [here](https://twiki.cern.ch/twiki/bin/view/LHCb/LoKiHybridFilters#Particle_Array_Functors)) that is given the array of particles in a single combination (the *children*) as input (in our case a kaon and a pion). This cut is applied before the vertex fit so it is typically used to save CPU time by performing some sanity cuts such as `AMAXDOCA` or `ADAMASS` before the CPU-consuming fit:
  
-	```python
-	d0_comb = "(AMAXDOCA('') < 0.2*mm) & (ADAMASS('D0') < 100*MeV)"
-	```
+    ```python
+    d0_comb = "(AMAXDOCA('') < 0.2*mm) & (ADAMASS('D0') < 100*MeV)"
+    ```
  
  - `MotherCut` is a selection LoKi particle functor that acts on the particle produced by the vertex fit (the *parent*) from the input particles, which allows to apply cuts on those variables that require a vertex, for example:
 
-```python
-# We can split long selections across multiple lines
-d0_mother = (
-  '(VFASPF(VCHI2/VDOF)< 9)'
-  '& (BPVDIRA > 0.9997)'
-  "& (ADMASS('D0') < 70*MeV)"
-)
-```
+    ```python
+    # We can split long selections across multiple lines
+    d0_mother = (
+      '(VFASPF(VCHI2/VDOF)< 9)'
+      '& (BPVDIRA > 0.9997)'
+      "& (ADMASS('D0') < 70*MeV)"
+    )
+    ```
 
 Then, we can build a combiner as
 
@@ -104,9 +104,11 @@ Now we have to build a `Selection` out of it so we can later on put all pieces t
 
 ```python
 from PhysSelPython.Wrappers import Selection
-d0_sel = Selection('Sel_D0',
-                   Algorithm=d0,
-                   RequiredSelections=[Pions, Kaons])
+d0_sel = Selection(
+    'Sel_D0',
+    Algorithm=d0,
+    RequiredSelections=[Pions, Kaons]
+)
 ```
 
 This two-step process for building the `Selection` (creating an algorithm and building a selection with it) can be simplified by using a helper function in the `PhysSelPython.Wrappers` module, called `SimpleSelection`.
@@ -116,13 +118,15 @@ With that in mind, we can rewrite the previous two pieces of code as
 ```python
 import GaudiConfUtils.ConfigurableGenerators as ConfigurableGenerators
 from PhysSelPython.Wrappers import SimpleSelection
-d0_sel = SimpleSelection("Sel_D0",
-                         ConfigurableGenerators.CombineParticles,
-                         [Pions, Kaons],
-                         DecayDescriptor='([D0 -> pi- K+]CC)',
-                         DaughtersCuts=d0_daughters,
-                         CombinationCut=d0_comb,
-                         MotherCut=d0_mother)
+d0_sel = SimpleSelection(
+    'Sel_D0',
+    ConfigurableGenerators.CombineParticles,
+    [Pions, Kaons],
+    DecayDescriptor='([D0 -> pi- K+]CC)',
+    DaughtersCuts=d0_daughters,
+    CombinationCut=d0_comb,
+    MotherCut=d0_mother
+)
 ```
 
 Note how we needed to use the `CombineParticles` from `GaudiConfUtils.ConfigurableGenerators` instead of the `PhysSelPython.Wrappers` one to make this work.
@@ -140,7 +144,7 @@ This is because the LHCb algorithms are configured as singletons and it is manda
 > This allows to reuse and reload algorithms that have already been created in the configuration sequence, eg, we could have reloaded the `"Combine_D0"` `CombineParticles` by name and modified it (even in another file loaded in the same `gaudirun.py` call!):
 >
 > ```python
-> d0_copy = CombineParticles("Combine_D0")
+> d0_copy = CombineParticles('Combine_D0')
 > print d0_copy.DecayDescriptor
 >```
 >

--- a/06-building-decays.md
+++ b/06-building-decays.md
@@ -63,10 +63,12 @@ This algorithm performs the combinatorics for us according to a given decay desc
 
  - `DaughtersCuts` is a dictionary that maps each child particle type to a LoKi particle functor that determines if that particular particle satisfies our selection criteria. Optionally, one can specify also a `Preambulo` property that allows us to make imports, preprocess functors, etc (more on this in the [LoKi functors](https://lhcb.github.io/first-analysis-steps/06-loki-functors.html) lesson). For example:
 
-	```python
-	d0_daughters = {'pi-': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)',
-					'K+': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)'}
-	```
+```python
+d0_daughters = {
+  'pi-': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)',
+  'K+': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)'
+}
+```
 
  - `CombinationCut` is a particle array LoKi functor (note the `A` prefix, see more [here](https://twiki.cern.ch/twiki/bin/view/LHCb/LoKiHybridFilters#Particle_Array_Functors)) that is given the array of particles in a single combination (the *children*) as input (in our case a kaon and a pion). This cut is applied before the vertex fit so it is typically used to save CPU time by performing some sanity cuts such as `AMAXDOCA` or `ADAMASS` before the CPU-consuming fit:
  
@@ -76,26 +78,33 @@ This algorithm performs the combinatorics for us according to a given decay desc
  
  - `MotherCut` is a selection LoKi particle functor that acts on the particle produced by the vertex fit (the *parent*) from the input particles, which allows to apply cuts on those variables that require a vertex, for example:
 
-	```python
-	d0_mother = "(VFASPF(VCHI2/VDOF)< 9) & (BPVDIRA > 0.9997) & (ADMASS('D0') < 70*MeV)"
-	```
+```python
+# We can split long selections across multiple lines
+d0_mother = (
+  '(VFASPF(VCHI2/VDOF)< 9)'
+  '& (BPVDIRA > 0.9997)'
+  "& (ADMASS('D0') < 70*MeV)"
+)
+```
 
 Then, we can build a combiner as
 
 ```python
 from Configurables import CombineParticles
-d0 = CombineParticles("Combine_D0",
-                      DecayDescriptor='([D0 -> pi- K+]CC)',
-                      DaughtersCuts=d0_daughters,
-                      CombinationCut=d0_comb,
-                      MotherCut=d0_mother)
+d0 = CombineParticles(
+    'Combine_D0',
+    DecayDescriptor='([D0 -> pi- K+]CC)',
+    DaughtersCuts=d0_daughters,
+    CombinationCut=d0_comb,
+    MotherCut=d0_mother
+)
 ```
 
 Now we have to build a `Selection` out of it so we can later on put all pieces together:
 
 ```python
 from PhysSelPython.Wrappers import Selection
-d0_sel = Selection("Sel_D0",
+d0_sel = Selection('Sel_D0',
                    Algorithm=d0,
                    RequiredSelections=[Pions, Kaons])
 ```
@@ -142,16 +151,23 @@ This is because the LHCb algorithms are configured as singletons and it is manda
 Now we can use another `CombineParticles` to build the D* with pions and the D0's as inputs, and applying a filtering only on the soft pion:
 
 ```python
-dstar_daughters = {'pi+': '(TRCHI2DOF < 3) & (PT > 100*MeV)'}
+dstar_daughters = {
+  'pi+': '(TRCHI2DOF < 3) & (PT > 100*MeV)'
+}
 dstar_comb = "(ADAMASS('D*(2010)+') < 400*MeV)"
-dstar_mother = "(abs(M-MAXTREE('D0'==ABSID,M)-145.42) < 10*MeV) & (VFASPF(VCHI2/VDOF)< 9)"
-dstar_sel = SimpleSelection('Sel_Dstar',
-                            ConfigurableGenerators.CombineParticles,
-                            [d0_sel, Pions],
-                            DecayDescriptor='[D*(2010)+ -> D0 pi+]cc',
-                            DaughtersCuts=dstar_daughters,
-                            CombinationCut=dstar_comb,
-                            MotherCut=dstar_mother)
+dstar_mother = (
+    "(abs(M-MAXTREE('D0'==ABSID,M)-145.42) < 10*MeV)"
+    '& (VFASPF(VCHI2/VDOF)< 9)'
+)
+dstar_sel = SimpleSelection(
+    'Sel_Dstar',
+    ConfigurableGenerators.CombineParticles,
+    [d0_sel, Pions],
+    DecayDescriptor='[D*(2010)+ -> D0 pi+]cc',
+    DaughtersCuts=dstar_daughters,
+    CombinationCut=dstar_comb,
+    MotherCut=dstar_mother
+)
 ```
 
 > ## Building shared selections {.callout}
@@ -161,18 +177,25 @@ dstar_sel = SimpleSelection('Sel_Dstar',
 > 
 > ```python
 > from Configurables import FilterDesktop
-> soft_pion = FilterDesktop("Filter_SoftPi",
+> soft_pion = FilterDesktop('Filter_SoftPi',
 >                           Code='(TRCHI2DOF < 3) & (PT > 100*MeV)')
-> soft_pion_sel = Selection("Sel_SoftPi",
+> soft_pion_sel = Selection('Sel_SoftPi',
 >                           Algorithm=soft_pion,
 >                           RequiredSelections=[Pions])
-> dstar = CombineParticles("CombineDstar",
->                          DecayDescriptor='[D*(2010)+ -> D0 pi+]cc',
->                          CombinationCut="(ADAMASS('D*(2010)+') < 400*MeV)",
->                          MotherCut="(abs(M-MAXTREE('D0'==ABSID,M)-145.42) < 10*MeV) & (VFASPF(VCHI2/VDOF)< 9)")
-> dstar_sel = Selection("Sel_Dstar",
->                       Algorithm=dstar,
->                       RequiredSelections=[d0_sel, soft_pion_sel])
+> dstar = CombineParticles(
+>     'CombineDstar',
+>     DecayDescriptor='[D*(2010)+ -> D0 pi+]cc',
+>     CombinationCut="(ADAMASS('D*(2010)+') < 400*MeV)",
+>     MotherCut=(
+>         "(abs(M-MAXTREE('D0'==ABSID,M)-145.42) < 10*MeV)"
+>         '& (VFASPF(VCHI2/VDOF)< 9)'
+>     )
+> )
+> dstar_sel = Selection(
+>     'Sel_Dstar',
+>     Algorithm=dstar,
+>     RequiredSelections=[d0_sel, soft_pion_sel]
+> )
 > ```
 >
 > This allows us to save time by performing the filtering of the soft pions only once, and to keep all the common cuts in a single place, avoiding duplication of code.

--- a/09-minimal-dv-job.md
+++ b/09-minimal-dv-job.md
@@ -136,7 +136,7 @@ from GaudiConf import IOHelper
 
 # Use the local input data
 IOHelper().inputFiles([
-  './00035742_00000002_1.allstreams.dst'
+    './00035742_00000002_1.allstreams.dst'
 ], clear=True)
 ```
 

--- a/10-eos-storage.md
+++ b/10-eos-storage.md
@@ -70,8 +70,8 @@ Make a copy of `first-job.py` and add the following three lines
 before the `j.submit()` line:
 
 ```python
-f = MassStorageFile("DVntuple.root")
-f.outputfilenameformat = "/starterkit/{jid}_{fname}"
+f = MassStorageFile('DVntuple.root')
+f.outputfilenameformat = '/starterkit/{jid}_{fname}'
 j.outputfiles = [f] 
 ```
 
@@ -161,5 +161,5 @@ your EOS directory with `eosumount ~/eos`.
 > You can also open ROOT files on EOS directly from your ROOT
 > script with:
 > ```python
-> TFile::Open("root://eoslhcb.cern.ch//eos/lhcb/user/a/another/starterkit/myfavouritefile.root")
+> TFile::Open('root://eoslhcb.cern.ch//eos/lhcb/user/a/another/starterkit/myfavouritefile.root')
 > ```

--- a/11-davinci-grid.md
+++ b/11-davinci-grid.md
@@ -32,7 +32,7 @@ To create your first `ganga` job type the following:
 ```python
 j = Job(application=DaVinci(version='v36r6'))
 j.backend = Dirac()
-j.name = "First ganga job"
+j.name = 'First ganga job'
 j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
 j.application.optsfile = 'code/11-davinci-grid/ntuple_options_grid.py'
 ```
@@ -60,7 +60,7 @@ Place the following in a file called [`first-job.py`](code/11-davinci-grid/first
 ```python
 j = Job(application=DaVinci(version='v36r6'))
 j.backend = Dirac()
-j.name = "First ganga job"
+j.name = 'First ganga job'
 j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
 j.application.optsfile = 'code/11-davinci-grid/ntuple_options_grid.py'
 j.submit()
@@ -89,7 +89,7 @@ Once your job has finished its status will be `completed`. Check this
 by typing `jobs` or by printing out the status of one particular job:
 
 ```python
-print "Status of my job:", jobs(787).status
+print 'Status of my job:', jobs(787).status
 ```
 
 The next thing to do is to find the output of your job. Two things can
@@ -106,7 +106,7 @@ property of your job.
 
 ```python
 output = job(787).outputdir
-print "Job output stored in:", output
+print 'Job output stored in:', output
 ```
 
 Take a look at the contents of this directory.

--- a/12-add-tupletools.md
+++ b/12-add-tupletools.md
@@ -126,35 +126,43 @@ To add LoKi-based leaves to the tree, we need to use the `LoKi::Hybrid::TupleToo
 
   - Its *name*, specified in the `addTupleTool` call after a `/`.  This is very useful (and recommended) if we want to have different `LoKi::Hybrid::TupleTool` for each of our branches. For instance, we may want to add different information for the D*, the D0 and the soft $\pi$:
     ```python
-    dstar_hybrid = dtt.Dstar.addTupleTool("LoKi::Hybrid::TupleTool/LoKi_Dstar")
-    d0_hybrid = dtt.D0.addTupleTool("LoKi::Hybrid::TupleTool/LoKi_D0")
-    pisoft_hybrid = dtt.pisoft.addTupleTool("LoKi::Hybrid::TupleTool/LoKi_PiSoft")
+    dstar_hybrid = dtt.Dstar.addTupleTool('LoKi::Hybrid::TupleTool/LoKi_Dstar')
+    d0_hybrid = dtt.D0.addTupleTool('LoKi::Hybrid::TupleTool/LoKi_D0')
+    pisoft_hybrid = dtt.pisoft.addTupleTool('LoKi::Hybrid::TupleTool/LoKi_PiSoft')
     ```
   - The `Preambulo` property, which lets us perform preprocessing of the LoKi functors to simplify the code that is used to fill the leaves, for example creating combinations of LoKi functors or performing mathematical operations:
     ```python
-    preamble = ['DZ = VFASPF(VZ) - BPV(VZ)',
-                'TRACK_MAX_PT = MAXTREE(ISBASIC & HASTRACK, PT, -1)']
+    preamble = [
+        'DZ = VFASPF(VZ) - BPV(VZ)',
+        'TRACK_MAX_PT = MAXTREE(ISBASIC & HASTRACK, PT, -1)'
+    ]
     dstar_hybrid.Preambulo = preamble
     d0_hybrid.Preambulo = preamble
     ```
   - The `Variables` property, consisting of a `dict` of (variable name, LoKi functor) pairs. In here, LoKi functors can be used, as well as any variable we may have defined in the `Preambulo`:
     ```python
-    dstar_hybrid.Variables = {'mass': 'MM',
-                              'mass_D0': 'CHILD(MM, 1)',
-                              'pt': 'PT',
-                              'dz': 'DZ',
-                              'dira': 'BPVDIRA',
-                              'max_pt': 'MAXTREE(ISBASIC & HASTRACK, PT, -1)',
-                              'max_pt_preambulo': 'TRACK_MAX_PT',
-                              'sum_pt_pions': 'SUMTREE(211 == ABSID, PT)'
-                              'n_highpt_tracks': 'NINTREE(ISBASIC & HASTRACK & (PT > 1500*MeV))'}
-    d0_hybrid.Variables = {'mass': 'MM',
-                           'pt': 'PT',
-                           'dira': 'BPVDIRA',
-                           'vtx_chi2': 'VFASPF(VCHI2)',
-                           'dz': 'DZ'}
-    pisoft_hybrid.Variables = {'p': 'P',
-                               'pt': 'PT'}
+    dstar_hybrid.Variables = {
+        'mass': 'MM',
+        'mass_D0': 'CHILD(MM, 1)',
+        'pt': 'PT',
+        'dz': 'DZ',
+        'dira': 'BPVDIRA',
+        'max_pt': 'MAXTREE(ISBASIC & HASTRACK, PT, -1)',
+        'max_pt_preambulo': 'TRACK_MAX_PT',
+        'sum_pt_pions': 'SUMTREE(211 == ABSID, PT)'
+        'n_highpt_tracks': 'NINTREE(ISBASIC & HASTRACK & (PT > 1500*MeV))'
+    }
+    d0_hybrid.Variables = {
+        'mass': 'MM',
+        'pt': 'PT',
+        'dira': 'BPVDIRA',
+        'vtx_chi2': 'VFASPF(VCHI2)',
+        'dz': 'DZ'
+    }
+    pisoft_hybrid.Variables = {
+        'p': 'P',
+        'pt': 'PT'
+    }
     ```
 
 In the code snippets specified above (available [here](code/12-add-tupletools/ntuple_options_loki.py)), there are several things to notice:

--- a/14-rerun-stripping.md
+++ b/14-rerun-stripping.md
@@ -41,7 +41,7 @@ strip = 'stripping21'
 streams = buildStreams(stripping=strippingConfiguration(strip),
                        archive=strippingArchive(strip))
 
-custom_stream = StrippingStream("CustomStream")
+custom_stream = StrippingStream('CustomStream')
 custom_line = 'StrippingD2hhCompleteEventPromptDst2D2RSLine'
 
 for stream in streams:

--- a/22-decay-tree-fitter.md
+++ b/22-decay-tree-fitter.md
@@ -28,7 +28,7 @@ So how do we use a `TupleToolDecayTreeFitter` to our DaVinci script? Let's creat
 ```python
 from Configurables import TupleToolDecayTreeFitter,TupleToolDecay
 dtt.addBranches({
-    'Dstar' : '[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
+    'Dstar': '[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
 }) 
 ```
 To this branch we can now apply the `TupleToolDecayTreeFitter`. 
@@ -39,7 +39,7 @@ Now we can proceed with the configuration of the fitter. We are going to constra
 ```python
 dtt.Dstar.ConsD.constrainToOriginVertex = True
 dtt.Dstar.ConsD.Verbose = True
-dtt.Dstar.ConsD.daughtersToConstrain = [ 'D0' ]
+dtt.Dstar.ConsD.daughtersToConstrain = ['D0']
 ```
 Note that you can constrain more than one intermediate state at once if that fits your decay. 
 

--- a/code/06-building-decays/build_decays.py
+++ b/code/06-building-decays/build_decays.py
@@ -1,6 +1,11 @@
 """Build D* -> D0 (->K pi) pi decays from scratch."""
 
-from PhysSelPython.Wrappers import Selection, SelectionSequence, DataOnDemand, SimpleSelection
+from PhysSelPython.Wrappers import (
+    Selection,
+    SelectionSequence,
+    DataOnDemand,
+    SimpleSelection
+)
 import GaudiConfUtils.ConfigurableGenerators as ConfigurableGenerators
 from Configurables import CombineParticles, DaVinci
 

--- a/code/06-building-decays/build_decays.py
+++ b/code/06-building-decays/build_decays.py
@@ -7,10 +7,17 @@ from Configurables import CombineParticles, DaVinci
 Pions = DataOnDemand('Phys/StdAllNoPIDsPions/Particles')
 Kaons = DataOnDemand('Phys/StdAllLooseKaons/Particles')
 
-d0_daughters = {'pi-': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)',
-                'K+': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)'}
+d0_daughters = {
+    'pi-': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)',
+    'K+': '(PT > 750*MeV) & (P > 4000*MeV) & (MIPCHI2DV(PRIMARY) > 4)'
+}
 d0_comb = "(AMAXDOCA('') < 0.2*mm) & (ADAMASS('D0') < 100*MeV)"
-d0_mother = "(VFASPF(VCHI2/VDOF)< 9) & (BPVDIRA > 0.9997) & (ADMASS('D0') < 70*MeV)"
+# We can split long selections across multiple lines
+d0_mother = (
+    '(VFASPF(VCHI2/VDOF)< 9)'
+    '& (BPVDIRA > 0.9997)'
+    "& (ADMASS('D0') < 70*MeV)"
+)
 
 d0 = CombineParticles('Combine_D0',
                       DecayDescriptor='([D0 -> pi- K+]CC)',
@@ -18,24 +25,26 @@ d0 = CombineParticles('Combine_D0',
                       CombinationCut=d0_comb,
                       MotherCut=d0_mother)
 
-d0_sel = Selection("Sel_D0",
+d0_sel = Selection('Sel_D0',
                    Algorithm=d0,
                    RequiredSelections=[Pions, Kaons])
 
 dstar_daughters = {'pi+': '(TRCHI2DOF < 3) & (PT > 100*MeV)'}
 dstar_comb = "(ADAMASS('D*(2010)+') < 400*MeV)"
-dstar_mother = "(abs(M-MAXTREE('D0'==ABSID,M)-145.42) < 10*MeV) & (VFASPF(VCHI2/VDOF)< 9)"
-dstar_sel = SimpleSelection('Sel_Dstar',
-                            ConfigurableGenerators.CombineParticles,
-                            [d0_sel, Pions],
-                            DecayDescriptor='[D*(2010)+ -> D0 pi+]cc',
-                            DaughtersCuts=dstar_daughters,
-                            CombinationCut=dstar_comb,
-                            MotherCut=dstar_mother)
+dstar_mother = (
+    "(abs(M-MAXTREE('D0'==ABSID,M)-145.42) < 10*MeV)"
+    '& (VFASPF(VCHI2/VDOF)< 9)'
+)
+dstar_sel = SimpleSelection(
+    'Sel_Dstar',
+    ConfigurableGenerators.CombineParticles,
+    [d0_sel, Pions],
+    DecayDescriptor='[D*(2010)+ -> D0 pi+]cc',
+    DaughtersCuts=dstar_daughters,
+    CombinationCut=dstar_comb,
+    MotherCut=dstar_mother
+)
 
 dstar_seq = SelectionSequence('Dstar_Seq', TopSelection=dstar_sel)
 
 DaVinci().UserAlgorithms += [dstar_seq.sequence()]
-
-
-# EOF

--- a/code/09-minimal-dv/ntuple_options.py
+++ b/code/09-minimal-dv/ntuple_options.py
@@ -24,5 +24,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-  './00035742_00000002_1.allstreams.dst'
+    './00035742_00000002_1.allstreams.dst'
 ], clear=True)

--- a/code/11-davinci-grid/first-job.py
+++ b/code/11-davinci-grid/first-job.py
@@ -1,6 +1,12 @@
 j = Job(application=DaVinci(version='v36r6'))
 j.backend = Dirac()
 j.name = 'First ganga job'
-j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
+j.inputdata = j.application.readInputData((
+    'data/'
+    'MC_2012_27163003_Beam4000GeV2012MagDownNu2.5'
+    'Pythia8_Sim08e_Digi13_'
+    'Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_'
+    'ALLSTREAMS.DST.py'
+))
 j.application.optsfile = 'code/11-davinci-grid/ntuple_options_grid.py'
 j.submit()

--- a/code/11-davinci-grid/first-job.py
+++ b/code/11-davinci-grid/first-job.py
@@ -1,6 +1,6 @@
 j = Job(application=DaVinci(version='v36r6'))
 j.backend = Dirac()
-j.name = "First ganga job"
+j.name = 'First ganga job'
 j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
 j.application.optsfile = 'code/11-davinci-grid/ntuple_options_grid.py'
 j.submit()

--- a/code/12-add-tupletools/ntuple_options.py
+++ b/code/12-add-tupletools/ntuple_options.py
@@ -14,11 +14,13 @@ track_tool = dtt.addTupleTool('TupleToolTrackInfo')
 track_tool.Verbose = True
 dtt.addTupleTool('TupleToolPrimaries')
 
-dtt.addBranches({'Dstar' : '^[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
-                 'D0'    : '[D*(2010)+ -> ^(D0 -> K- pi+) pi+]CC',
-                 'Kminus': '[D*(2010)+ -> (D0 -> ^K- pi+) pi+]CC',
-                 'piplus': '[D*(2010)+ -> (D0 -> K- ^pi+) pi+]CC',
-                 'pisoft': '[D*(2010)+ -> (D0 -> K- pi+) ^pi+]CC'})
+dtt.addBranches({
+    'Dstar': '[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
+    'D0': '[D*(2010)+ -> ^(D0 -> K- pi+) pi+]CC',
+    'Kminus': '[D*(2010)+ -> (D0 -> ^K- pi+) pi+]CC',
+    'piplus': '[D*(2010)+ -> (D0 -> K- ^pi+) pi+]CC',
+    'pisoft': '[D*(2010)+ -> (D0 -> K- pi+) ^pi+]CC'
+})
 
 dtt.D0.addTupleTool('TupleToolPropertime')
 
@@ -35,5 +37,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-  './00035742_00000002_1.allstreams.dst'
+    './00035742_00000002_1.allstreams.dst'
 ], clear=True)

--- a/code/12-add-tupletools/ntuple_options_loki.py
+++ b/code/12-add-tupletools/ntuple_options_loki.py
@@ -14,39 +14,47 @@ track_tool = dtt.addTupleTool('TupleToolTrackInfo')
 track_tool.Verbose = True
 dtt.addTupleTool('TupleToolPrimaries')
 
-dtt.addBranches({'Dstar' : '^[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
-                 'D0'    : '[D*(2010)+ -> ^(D0 -> K- pi+) pi+]CC',
-                 'Kminus': '[D*(2010)+ -> (D0 -> ^K- pi+) pi+]CC',
-                 'piplus': '[D*(2010)+ -> (D0 -> K- ^pi+) pi+]CC',
-                 'pisoft': '[D*(2010)+ -> (D0 -> K- pi+) ^pi+]CC'})
+dtt.addBranches({
+    'Dstar': '[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
+    'D0': '[D*(2010)+ -> ^(D0 -> K- pi+) pi+]CC',
+    'Kminus': '[D*(2010)+ -> (D0 -> ^K- pi+) pi+]CC',
+    'piplus': '[D*(2010)+ -> (D0 -> K- ^pi+) pi+]CC',
+    'pisoft': '[D*(2010)+ -> (D0 -> K- pi+) ^pi+]CC'
+})
 
 dtt.D0.addTupleTool('TupleToolPropertime')
 
 # Add LoKi HybridTools
-dstar_hybrid = dtt.Dstar.addTupleTool("LoKi::Hybrid::TupleTool/LoKi_Dstar")
-d0_hybrid = dtt.D0.addTupleTool("LoKi::Hybrid::TupleTool/LoKi_D0")
-pisoft_hybrid = dtt.pisoft.addTupleTool("LoKi::Hybrid::TupleTool/LoKi_PiSoft")
+dstar_hybrid = dtt.Dstar.addTupleTool('LoKi::Hybrid::TupleTool/LoKi_Dstar')
+d0_hybrid = dtt.D0.addTupleTool('LoKi::Hybrid::TupleTool/LoKi_D0')
+pisoft_hybrid = dtt.pisoft.addTupleTool('LoKi::Hybrid::TupleTool/LoKi_PiSoft')
 
 preamble = ['DZ = VFASPF(VZ) - BPV(VZ)',
             'TRACK_MAX_PT = MAXTREE(ISBASIC & HASTRACK, PT, -1)']
 dstar_hybrid.Preambulo = preamble
 d0_hybrid.Preambulo = preamble
 
-dstar_hybrid.Variables = {'mass': 'MM',
-                          'mass_D0': 'CHILD(MM, 1)',
-                          'pt': 'PT',
-                          'dz': 'DZ',
-                          'dira': 'BPVDIRA',
-                          'max_pt': 'MAXTREE(ISBASIC & HASTRACK, PT, -1)',
-                          'max_pt_preambulo': 'TRACK_MAX_PT',
-                          'n_highpt_tracks': 'NINTREE(ISBASIC & HASTRACK & (PT > 1500*MeV))'}
-d0_hybrid.Variables = {'mass': 'MM',
-                       'pt': 'PT',
-                       'dira': 'BPVDIRA',
-                       'vtx_chi2': 'VFASPF(VCHI2)',
-                       'dz': 'DZ'}
-pisoft_hybrid.Variables = {'p': 'P',
-                           'pt': 'PT'}
+dstar_hybrid.Variables = {
+    'mass': 'MM',
+    'mass_D0': 'CHILD(MM, 1)',
+    'pt': 'PT',
+    'dz': 'DZ',
+    'dira': 'BPVDIRA',
+    'max_pt': 'MAXTREE(ISBASIC & HASTRACK, PT, -1)',
+    'max_pt_preambulo': 'TRACK_MAX_PT',
+    'n_highpt_tracks': 'NINTREE(ISBASIC & HASTRACK & (PT > 1500*MeV))'
+}
+d0_hybrid.Variables = {
+    'mass': 'MM',
+    'pt': 'PT',
+    'dira': 'BPVDIRA',
+    'vtx_chi2': 'VFASPF(VCHI2)',
+    'dz': 'DZ'
+}
+pisoft_hybrid.Variables = {
+    'p': 'P',
+    'pt': 'PT'
+}
 
 
 # Configure DaVinci
@@ -62,5 +70,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-  './00035742_00000002_1.allstreams.dst'
+    './00035742_00000002_1.allstreams.dst'
 ], clear=True)

--- a/code/12-split-jobs/first-job.py
+++ b/code/12-split-jobs/first-job.py
@@ -1,6 +1,6 @@
 j = Job(application=DaVinci(version='v36r6'))
 j.backend = Dirac()
-j.name = "First ganga job"
+j.name = 'First ganga job'
 j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
 j.application.optsfile = 'code/11-davinci-grid/ntuple_options_grid.py'
 j.splitter = SplitByFiles(filesPerJob=1)

--- a/code/12-split-jobs/first-job.py
+++ b/code/12-split-jobs/first-job.py
@@ -1,7 +1,13 @@
 j = Job(application=DaVinci(version='v36r6'))
 j.backend = Dirac()
 j.name = 'First ganga job'
-j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
+j.inputdata = j.application.readInputData((
+    'data/'
+    'MC_2012_27163003_Beam4000GeV2012MagDownNu2.5'
+    'Pythia8_Sim08e_Digi13_'
+    'Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_'
+    'ALLSTREAMS.DST.py'
+))
 j.application.optsfile = 'code/11-davinci-grid/ntuple_options_grid.py'
 j.splitter = SplitByFiles(filesPerJob=1)
 j.submit()

--- a/code/14-rerun-stripping/options.py
+++ b/code/14-rerun-stripping/options.py
@@ -1,15 +1,23 @@
-
-# This options file demonstrates how to run a stripping line
-# from a specific stripping version on a local MC DST file
-# It is based on the minimal DaVinci DecayTreeTuple example
+"""
+This options file demonstrates how to run a stripping line
+from a specific stripping version on a local MC DST file
+It is based on the minimal DaVinci DecayTreeTuple example
+"""
 
 from StrippingConf.Configuration import StrippingConf, StrippingStream
 from StrippingSettings.Utils import strippingConfiguration
 from StrippingArchive.Utils import buildStreams
 from StrippingArchive import strippingArchive
+from Configurables import (
+    EventNodeKiller,
+    ProcStatusCheck,
+    DaVinci,
+    DecayTreeTuple
+)
+from GaudiConf import IOHelper
+from DecayTreeTuple.Configuration import *
 
 # Node killer: remove the previous Stripping
-from Configurables import EventNodeKiller
 event_node_killer = EventNodeKiller('StripKiller')
 event_node_killer.Nodes = ['/Event/AllStreams', '/Event/Strip']
 
@@ -19,7 +27,7 @@ strip = 'stripping21'
 streams = buildStreams(stripping=strippingConfiguration(strip),
                        archive=strippingArchive(strip))
 
-custom_stream = StrippingStream("CustomStream")
+custom_stream = StrippingStream('CustomStream')
 custom_line = 'StrippingD2hhCompleteEventPromptDst2D2RSLine'
 
 for stream in streams:
@@ -30,17 +38,12 @@ for stream in streams:
 line = 'D2hhCompleteEventPromptDst2D2RSLine'
 
 # Create the actual Stripping configurable
-from Configurables import ProcStatusCheck
 filterBadEvents = ProcStatusCheck()
 
 sc = StrippingConf(Streams=[custom_stream],
                    MaxCandidates=2000,
                    AcceptBadEvents=False,
                    BadEventSelection=filterBadEvents)
-
-from GaudiConf import IOHelper
-from Configurables import DaVinci, DecayTreeTuple
-from DecayTreeTuple.Configuration import *
 
 # The output is placed directly into Phys, so we only need to
 # define the stripping line here
@@ -68,5 +71,5 @@ DaVinci().EvtMax = 5000
 
 # Use the local input data
 IOHelper().inputFiles([
-  './00035742_00000002_1.allstreams.dst'
+    './00035742_00000002_1.allstreams.dst'
 ], clear=True)

--- a/code/18-switch-mass-hypo/ntuple_switchHypo.py
+++ b/code/18-switch-mass-hypo/ntuple_switchHypo.py
@@ -1,6 +1,8 @@
 from GaudiConf import IOHelper
-from Configurables import DaVinci, DecayTreeTuple
+from Configurables import DaVinci, DecayTreeTuple, SubstitutePID
+from PhysSelPython.Wrappers import Selection, SelectionSequence, DataOnDemand
 from DecayTreeTuple.Configuration import *
+
 
 # Stream and stripping line we want to use
 stream = 'AllStreams'
@@ -8,25 +10,26 @@ line = 'D2hhCompleteEventPromptDst2D2RSLine'
 tesLoc = '/Event/{0}/Phys/{1}/Particles'.format(stream, line)
 
 # get the selection(s) created by the stripping
-from PhysSelPython.Wrappers import Selection
-from PhysSelPython.Wrappers import SelectionSequence
-from PhysSelPython.Wrappers import DataOnDemand
+strippingSels = [DataOnDemand(Location=tesLoc)]
 
-strippingSels = [DataOnDemand(Location=tesLoc)] 
-
-# configure an algorithm to substitute the Kaon in the D0-decay by a second pion 
-from Configurables import SubstitutePID
+# configure an algorithm to substitute the Kaon in the D0-decay by a second
+# pion
 subs = SubstitutePID(
-        'MakeD02pipi',
-        Code = "DECTREE('[D*(2010)+ -> (D0 -> K- pi+) pi+]CC')",
-        Substitutions = { # note that SubstitutePID can't handle automatic CC
-        'Charm -> (D0 -> ^K- pi+) Meson' : 'pi-', 
-        'Charm -> (D0 -> ^K+ pi-) Meson' : 'pi+', 
-        }
+    'MakeD02pipi',
+    Code="DECTREE('[D*(2010)+ -> (D0 -> K- pi+) pi+]CC')",
+    # note that SubstitutePID can't handle automatic CC
+    Substitutions={
+        'Charm -> (D0 -> ^K- pi+) Meson': 'pi-',
+        'Charm -> (D0 -> ^K+ pi-) Meson': 'pi+'
+    }
 )
 
 # create a selection using the substitution algorithm
-selSub = Selection("Dst2D0pi_D02pipi_Sel", Algorithm=subs, RequiredSelections=strippingSels)
+selSub = Selection(
+    'Dst2D0pi_D02pipi_Sel',
+    Algorithm=subs,
+    RequiredSelections=strippingSels
+)
 # in order to add the selection into the program make a sequence
 selSeq = SelectionSequence('SelSeq', TopSelection=selSub)
 
@@ -55,5 +58,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-  './00035742_00000002_1.allstreams.dst'
+    './00035742_00000002_1.allstreams.dst'
 ], clear=True)

--- a/code/22-decay-tree-fitter/ntuple_DTF1.py
+++ b/code/22-decay-tree-fitter/ntuple_DTF1.py
@@ -14,12 +14,12 @@ dtt.Decay = '[D*(2010)+ -> ^(D0 -> ^K- ^pi+) ^pi+]CC'
 # add a kinematic fitter
 from Configurables import TupleToolDecayTreeFitter
 dtt.addBranches({
-    'Dstar' : '[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
-}) 
+    'Dstar': '[D*(2010)+ -> (D0 -> K- pi+) pi+]CC',
+})
 dtt.Dstar.addTupleTool(TupleToolDecayTreeFitter('ConsD'))
 dtt.Dstar.ConsD.constrainToOriginVertex = True
 dtt.Dstar.ConsD.Verbose = True
-dtt.Dstar.ConsD.daughtersToConstrain = [ 'D0' ]
+dtt.Dstar.ConsD.daughtersToConstrain = ['D0']
 
 
 # Configure DaVinci
@@ -35,5 +35,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-  './00035742_00000002_1.allstreams.dst'
+    './00035742_00000002_1.allstreams.dst'
 ], clear=True)

--- a/code/dst-explore.py
+++ b/code/dst-explore.py
@@ -105,9 +105,17 @@ old_decay_finder = appMgr.toolsvc().create(
 )
 
 # works
-# decay_desc = '[[B0]cc -> (^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-, ^K- ^K- ^pi+}) ^K-]cc'
+# decay_desc = (
+#     '[[B0]cc -> '
+#     '(^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-, ^K- ^K- ^pi+})'
+#     '^K-]cc'
+# )
 # doesn't work
-decay_desc = '[[B0]cc -> (^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-}) ^K-]cc'
+decay_desc = (
+    '[[B0]cc -> '
+    '(^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-})'
+    '^K-]cc'
+)
 old_decay_finder.setDecay(decay_desc)
 
 # process first event

--- a/code/dst-explore.py
+++ b/code/dst-explore.py
@@ -47,7 +47,7 @@ def nodes(evt, node=None):
     return nodenames
 
 
-def advance(decision='B02DKWSD2HHHBeauty2CharmLine'):
+def advance(decision):
     """Advance until stripping decision is true, returns
     number of events by which we advanced"""
     n = 0
@@ -95,28 +95,9 @@ print_decay = appMgr.toolsvc().create(
     'PrintDecayTreeTool', interface='IPrintDecayTreeTool'
 )
 
-# New style decay descriptors, also known as LoKi decays
-loki_decay_finder = appMgr.toolsvc().create(
+decay_finder = appMgr.toolsvc().create(
     'LoKi::Decay', interface='Decays::IDecay'
 )
-# Old style decay descriptors
-old_decay_finder = appMgr.toolsvc().create(
-    'DecayFinder', interface='IDecayFinder'
-)
-
-# works
-# decay_desc = (
-#     '[[B0]cc -> '
-#     '(^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-, ^K- ^K- ^pi+})'
-#     '^K-]cc'
-# )
-# doesn't work
-decay_desc = (
-    '[[B0]cc -> '
-    '(^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-})'
-    '^K-]cc'
-)
-old_decay_finder.setDecay(decay_desc)
 
 # process first event
 appMgr.run(1)
@@ -136,21 +117,21 @@ print '-'*80
 print evt['/Event/Strip/Phys/DecReports']
 
 
-# Figure out why your decay descriptor does not work
-# type the following into the python terminal
-# advance()
+"""
+To try and figure out why your decay descriptor does not work,
+type the following into the python terminal
 
-# stream = 'Bhadron'
-# line = 'B02DKWSD2HHHBeauty2CharmLine'
-# WS_candidates = evt['/Event/{0}/Phys/{1}/Particles'.format(stream, line)]
-# B = WS_candidates[0]
-# print_decay.printTree(B)
-# Can we find the decay?
-# old_decay_finder.hasDecay(WS_candidates)
+>>> advance()
+>>> stream = '$MYSTREAM'
+>>> line = '$MYLINE'
+>>> candidates = evt['/Event/{0}/Phys/{1}/Particles'.format(stream, line)]
+>>> head = candidates[0]
+>>> print_decay.printTree(head)
 
-# Beware, you can not repeatedly call this. It somehow keeps track
-# of how often it has been called/recursion stuff :-s
-# head = Particle()
-# old_decay_finder.findDecay(WS_candidates, head)
-# head will contain the head of the decay tree
-# print head
+Can we find match the candidate with the decay descriptor?
+
+>>> decay_finder.hasDecay(candidates)
+
+Beware, you can not repeatedly call this. It somehow keeps track
+of how often it has been called/recursion stuff :-s
+"""

--- a/code/dst-explore.py
+++ b/code/dst-explore.py
@@ -2,10 +2,19 @@ import sys
 
 import GaudiPython as GP
 from GaudiConf import IOHelper
-from Configurables import LHCbApp, ApplicationMgr, DataOnDemandSvc
-from Configurables import SimConf, DigiConf, DecodeRawEvent
-from Configurables import CondDB, DstConf, PhysConf
-from Configurables import LoKiSvc
+from Configurables import (
+    LHCbApp,
+    ApplicationMgr,
+    DataOnDemandSvc,
+    SimConf,
+    DigiConf,
+    DecodeRawEvent,
+    CondDB,
+    DstConf,
+    PhysConf,
+    LoKiSvc,
+    DaVinci
+)
 
 # Some name shortcuts
 MCParticle = GP.gbl.LHCb.MCParticle
@@ -16,7 +25,7 @@ MCHit = GP.gbl.LHCb.MCHit
 
 def nodes(evt, node=None):
     nodenames = []
-    
+
     if node is None:
         root = evt.retrieveObject('')
         node = root.registry()
@@ -26,16 +35,17 @@ def nodes(evt, node=None):
         for l in evt.leaves(node):
             # skip a location that takes forever to load
             # XXX How to detect these automatically??
-            if "Swum" in l.identifier():
+            if 'Swum' in l.identifier():
                 continue
-            
+
             temp = evt[l.identifier()]
             nodenames += nodes(evt, l)
-                    
+
     else:
         nodenames.append(node.identifier())
 
     return nodenames
+
 
 def advance(decision='B02DKWSD2HHHBeauty2CharmLine'):
     """Advance until stripping decision is true, returns
@@ -44,8 +54,8 @@ def advance(decision='B02DKWSD2HHHBeauty2CharmLine'):
     while True:
         appMgr.run(1)
         n += 1
-        dec=evt['/Event/Strip/Phys/DecReports']
-        if dec.hasDecisionName("Stripping%sDecision"%decision):
+        dec = evt['/Event/Strip/Phys/DecReports']
+        if dec.hasDecisionName('Stripping{0}Decision'.format(decision)):
             break
 
     return n
@@ -53,11 +63,10 @@ def advance(decision='B02DKWSD2HHHBeauty2CharmLine'):
 
 # Configure all the unpacking, algorithms, tags and input files
 appConf = ApplicationMgr()
-appConf.ExtSvc+= ['ToolSvc', 'DataOnDemandSvc', LoKiSvc()]
+appConf.ExtSvc += ['ToolSvc', 'DataOnDemandSvc', LoKiSvc()]
 
-from Configurables import DaVinci
 dv = DaVinci()
-dv.DataType = "2012"
+dv.DataType = '2012'
 
 
 # disable for older versions of DV
@@ -68,32 +77,37 @@ dre = DecodeRawEvent()
 dre.DataOnDemand = True
 
 lhcbApp = LHCbApp()
-lhcbApp.Simulation = True 
+lhcbApp.Simulation = True
 CondDB().Upgrade = False
 # don't really need tags for looking around
-#LHCbApp().DDDBtag = ... 
-#LHCbApp().CondDBtag  = ...
+# LHCbApp().DDDBtag = ...
+# LHCbApp().CondDBtag  = ...
 
 # Pass file to open as first command line argument
 inputFiles = [sys.argv[-1]]
 IOHelper('ROOT').inputFiles(inputFiles)
-    
 
 # Configuration done, run time!
 appMgr = GP.AppMgr()
 evt = appMgr.evtsvc()
 
-print_decay = appMgr.toolsvc().create('PrintDecayTreeTool', interface="IPrintDecayTreeTool")
+print_decay = appMgr.toolsvc().create(
+    'PrintDecayTreeTool', interface='IPrintDecayTreeTool'
+)
 
 # New style decay descriptors, also known as LoKi decays
-loki_decay_finder = appMgr.toolsvc().create('LoKi::Decay', interface="Decays::IDecay")
+loki_decay_finder = appMgr.toolsvc().create(
+    'LoKi::Decay', interface='Decays::IDecay'
+)
 # Old style decay descriptors
-old_decay_finder = appMgr.toolsvc().create("DecayFinder", interface="IDecayFinder")
+old_decay_finder = appMgr.toolsvc().create(
+    'DecayFinder', interface='IDecayFinder'
+)
 
 # works
-#decay_desc = "[[B0]cc -> (^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-, ^K- ^K- ^pi+}) ^K-]cc"
+# decay_desc = '[[B0]cc -> (^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-, ^K- ^K- ^pi+}) ^K-]cc'
 # doesn't work
-decay_desc = "[[B0]cc -> (^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-}) ^K-]cc"
+decay_desc = '[[B0]cc -> (^D- => {^K- ^K+ ^pi-, ^K- ^pi+ ^pi-,^pi+ ^pi- ^pi-}) ^K-]cc'
 old_decay_finder.setDecay(decay_desc)
 
 # process first event
@@ -105,28 +119,30 @@ evt.dump()
 # print out "all" TES locations
 # prints out packed locations, so you need to know
 # what the unpacked location is called to actually access it
-print "-"*80
+print '-'*80
 for node in nodes(evt):
     print node
 
 # print out the stripping lines which fired for this event
-print "-"*80
+print '-'*80
 print evt['/Event/Strip/Phys/DecReports']
 
 
 # Figure out why your decay descriptor does not work
 # type the following into the python terminal
-#advance()
+# advance()
 
-#WS_candidates = evt['/Event/Bhadron/Phys/B02DKWSD2HHHBeauty2CharmLine/Particles']
-#B = WS_candidates[0]
-#print_decay.printTree(B)
+# stream = 'Bhadron'
+# line = 'B02DKWSD2HHHBeauty2CharmLine'
+# WS_candidates = evt['/Event/{0}/Phys/{1}/Particles'.format(stream, line)]
+# B = WS_candidates[0]
+# print_decay.printTree(B)
 # Can we find the decay?
-#old_decay_finder.hasDecay(WS_candidates)
+# old_decay_finder.hasDecay(WS_candidates)
 
 # Beware, you can not repeatedly call this. It somehow keeps track
 # of how often it has been called/recursion stuff :-s
-#head = Particle()
-#old_decay_finder.findDecay(WS_candidates, head)
+# head = Particle()
+# old_decay_finder.findDecay(WS_candidates, head)
 # head will contain the head of the decay tree
-#print head
+# print head


### PR DESCRIPTION
Related to #70, fixes (nearly) all of the warnings that [`pep8`](https://pypi.python.org/pypi/pep8) emits on everything in `code/`, and mirrors those changes in the `.md` lessons. I've tried to make the coding style consistent.

There's a whole bunch o' warnings from `data/` and `tools/` that I haven't tried to deal with.  The remaining stuff in `code/` is

```
code/dst-explore.py:108:80: E501 line too long (102 > 79 characters)
code/dst-explore.py:110:80: E501 line too long (86 > 79 characters)
code/11-davinci-grid/first-job.py:4:80: E501 line too long (187 > 79 characters)
code/12-split-jobs/first-job.py:4:80: E501 line too long (187 > 79 characters)
```

I'm not sure how to break these lines up. We could append [`# noqa`](https://github.com/jcrocholl/pep8/pull/136) to the lines, but then those comments would need to be explained, else they'll be copied.
