### PR TITLE
Use dst-explorer for 05-interactive-dst

### DIFF
--- a/05-interactive-dst.md
+++ b/05-interactive-dst.md
@@ -23,99 +23,38 @@ is not working as expected.
 The file we [downloaded from the grid](05-files-from-grid.html)
 contains simulated data, with stripping and trigger decisions
 and so on. Here we assumed the file you downloaded is called `00035742_00000002_1.allstreams.dst`.
-To take a look at the contents of the TES we need a simple
-options file:
-
-~~~ {.python}
-import sys
-
-import GaudiPython as GP
-from GaudiConf import IOHelper
-from Configurables import LHCbApp, ApplicationMgr, DataOnDemandSvc
-from Configurables import DecodeRawEvent
-from Configurables import CondDB
-from Configurables import DaVinci
-
-
-appConf = ApplicationMgr()
-
-dv = DaVinci()
-dv.DataType = "2012"
-
-dre = DecodeRawEvent()
-dre.DataOnDemand = True
-
-lhcbApp = LHCbApp()
-lhcbApp.Simulation = True
-CondDB().Upgrade = False
-
-# Pass file to open as first command line argument
-inputFiles = [sys.argv[-1]]
-IOHelper('ROOT').inputFiles(inputFiles)
-
-appMgr = GP.AppMgr()
-evt = appMgr.evtsvc()
-
-appMgr.run(1)
-
-evt.dump()
-~~~
-
-Place this into a file called `first.py` and run the following
-command in a new terminal:
+To take a look at the contents of the TES, we can use a script from Bender called dst-explorer,
+which can be run in a terminal like this:
 
 ```bash
-$ lb-run DaVinci v36r6 ipython -i first.py 00035742_00000002_1.allstreams.dst
+$ lb-run Bender v25r6 dst-explorer 00035742_00000002_1.allstreams.dst
 ```
+or
+```bash
+$ lb-run Bender v25r6 dst-explorer /lhcb/MC/2012/ALLSTREAMS.DST/00035742/0000/00035742_00000002_1.allstreams.dst
+```
+which will open a remote file using the LFN.
 
-This will open the DST and print out some of the TES locations
-which exist for this event. We are now ready to explore the TES,
-which is accessible via the `evt` variable. For example you could
+This will open the DST. We are now ready to explore the TES,
+using the `ls` and `get` methods.  For example you could
 look at the properties of some tracks for the first event by typing
 inside the python session:
 
 ```python
-tracks = evt['/Event/Rec/Track/Best']
+tracks = get("Rec/Track/Best")
 print tracks[0]
 ```
 
 The next question is, how do you know what TES locations that could
-exist? As we saw `evt.dump()` prints a few of them, but not all. In
-addition there are some special ones that only exist if you try to
-access them. The following snippet allows you to discover most TES
-locations that are interesting:
+exist? `ls()` prints a few of them, but not all.
+In addition there are some special ones that only exist if you try to
+access them, those are added to the list when calling `ls(ondemand=True).
+`ls(forceload=True)` will also try to load all sub-paths.
 
-```python
-def nodes(evt, node=None):
-    """List all nodes in `evt`"""
-    nodenames = []
-
-    if node is None:
-        root = evt.retrieveObject('')
-        node = root.registry()
-
-    if node.object():
-        nodenames.append(node.identifier())
-        for l in evt.leaves(node):
-            # skip a location that takes forever to load
-            # XXX How to detect these automatically??
-            if "Swum" in l.identifier():
-                continue
-
-            temp = evt[l.identifier()]
-            nodenames += nodes(evt, l)
-
-    else:
-        nodenames.append(node.identifier())
-
-    return nodenames
-```
-
-The easiest way to use it is to add it to your `first.py` script
-and re-run it with `ipython -i first.py 00035742_00000002_1.allstreams.dst`.
-This will list a large number of TES locations, but even so there
-are some which you have to know about. Another oddity is that some
-locations are "packed", for example: `/Event/AllStreams/pPhys/Particles`.
+`ls(ondemand=True, forceload=True)` will list a large number of TES
+locations, but even so there are some which you have to know about.
+Another oddity is that some locations are "packed", for example:
+`/Event/AllStreams/pPhys/Particles`.
 You can not access these directly at this location. Instead you
 have to know what location the contents will get unpacked to when
 you want to use it. Often you can just try removing the small `p`
@@ -123,51 +62,18 @@ from the location (`/Event/AllStreams/Phys/Particles`).
 
 You can also inspect the particles and vertices built by your stripping
 line. However not every event will contain a candidate for your line,
-so the first tool we need is something that will advance us until
-the stripping decision was positive:
+one of the methods in dst-explorer, `seekStripDecision` will advance us
+until the stripping decision was positive, e.g.
 
 ```python
-def advance(decision):
-    """Advance until stripping decision is true, returns
-    number of events by which we advanced"""
-    n = 0
-    while True:
-        appMgr.run(1)
-
-        if not evt["/Event/Rec/Header"]:
-            print "Reached end of input files"
-            break
-
-        n += 1
-        dec=evt['/Event/Strip/Phys/DecReports']
-        if dec.hasDecisionName("Stripping%sDecision"%decision):
-            break
-
-    return n
+seekStripDecision(".*D2hhCompleteEventPromptDst2D2RSLine.*")
 ```
 
-Add this to your script and restart `ipython` as before.
-
-> ## Detecting file ends {.callout}
->
-> It is not easy to detect that the input file has ended. Especially
-> if you want to get it right for data and simulation. Checking that
-> `/Event/Rec/Header` exists is a safe bet in simulation and data if
-> your file has been processed by `Brunel` (the event reconstruction
-> software. It might not work in other cases.
-
-Using the name of our stripping line we can now advance through the
-DST until we reach an event which contains a candidate:
+The candidates built for you can now be found at `/Event/AllStreams/Phys/D2hhCompleteEventPromptDst2D2RSLine/Particles`
+(the leading `/Event/` can be left out when retrieving event data from the TES):
 
 ```python
-line = 'D2hhCompleteEventPromptDst2D2RSLine'
-advance(line)
-```
-
-The candidates built for you can now be found at `/Event/AllStreams/Phys/D2hhCompleteEventPromptDst2D2RSLine/Particles`:
-
-```python
-cands = evt['/Event/AllStreams/Phys/D2hhCompleteEventPromptDst2D2RSLine/Particles']
+cands = get("AllStreams/Phys/D2hhCompleteEventPromptDst2D2RSLine/Particles")
 print cands.size()
 ```
 
@@ -178,14 +84,4 @@ one with:
 print cands[0]
 ```
 
-Which will print out some information about the [Particle](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/v36r6/doxygen/d0/d13/class_l_h_cb_1_1_particle.html#details). In our case a D*. You can access its daughters with
-`cands[0].daughtersVector()[0]` and `cands[0].daughtersVector()[1]`,
-which will be a D0 and a pion.
-
-There is a useful tool for printing out decay trees, which you can
-pass the top level particle to and it will print out the daughters etc:
-
-```
-print_decay = appMgr.toolsvc().create('PrintDecayTreeTool', interface="IPrintDecayTreeTool")
-print_decay.printTree(cands[0])
-```
+Which will print out some information about the [Particle](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/v36r6/doxygen/d0/d13/class_l_h_cb_1_1_particle.html#details). In our case a D*.

--- a/06-loki-functors.md
+++ b/06-loki-functors.md
@@ -36,7 +36,7 @@ To understand what we can do with LoKi functors, we will start with exploring a 
 Open the DST and get the first candidate in the `D2hhCompleteEventPromptDst2D2RS` line:
 
 ```python
-cands = evt['/Event/AllStreams/Phys/D2hhCompleteEventPromptDst2D2RSLine/Particles']
+cands = get('AllStreams/Phys/D2hhCompleteEventPromptDst2D2RSLine/Particles')
 cand = cands[0]
 ```
 
@@ -47,14 +47,6 @@ from LoKiPhys.decorators import PT, MM
 print PT(cand)
 print MM(cand)
 ```
-
-You will see an error when loading the functors
-```
-LoKiSvc.REPORT      ERROR LoKi::AuxDesktopBase: 	loadDesktop(): unable to load IPhysDesktop! StatusCode=FAILURE
-LoKiSvc.REPORT      ERROR The   ERROR message is suppressed : 'LoKi::AuxDesktopBase: 	loadDesktop(): unable to load IPhysDesktop!' StatusCode=FAILURE
-```
-This is related to the fact that some functors need to run in the `DaVinci` scope and they are all loaded in the `LoKiPhys.decorators` module, but it's harmless in the examples we will use.
-Additionally, if the import is made *before* the instantiation of the `ApplicationMgr`, there will be no warnings.
 
 If we want to get the properties of the B vertex, for example its $\chi^2$, we need to pass the correct object to the LoKi functors
 
@@ -75,8 +67,8 @@ The calculation of some of the properties, such as the IP or DIRA, require the k
 In `GaudPython`, we can get the PVs ourselves.
 
 ```python
-pv_finder_tool = appMgr.toolsvc().create('GenericParticle2PVRelator<_p2PVWithIPChi2, OfflineDistanceCalculatorName>/P2PVWithIPChi2', interface='IRelatedPVFinder')
-pvs = evt['/Event/AllStreams/Rec/Vertex/Primary']
+pv_finder_tool = gaudi.toolsvc().create('GenericParticle2PVRelator<_p2PVWithIPChi2, OfflineDistanceCalculatorName>/P2PVWithIPChi2', interface='IRelatedPVFinder')
+pvs = get("Rec/Vertex/Primary")
 best_pv = pv_finder_tool.relatedPV(cand, pvs)
 from LoKiPhys.decorators import DIRA
 print DIRA(best_pv)(cand)


### PR DESCRIPTION
I had a look at a few of the tutorials (they look very nice; I will try to find a bit of time to contribute), and with the "interactive dst" one I had the feeling that this is a lot more convenient with the bender tools, so I went through it and replaced the gaudipython snippets with dst-explorer commands, and removed a few things (explanation of the loadDesktop warning, catching the end of the file) that are not necessary in this case... apologies if I entirely missed the point.
