### PR TITLE
Add instructions for changing default shell

### DIFF
--- a/00-prerequisites.md
+++ b/00-prerequisites.md
@@ -94,6 +94,24 @@ Proxies uploaded:
 If you can successfully execute all of the above steps, you are ready to go for 
 the workshop!
 
+> ## Using Bash {.callout}
+>
+> The [Bash shell](http://en.wikipedia.org/wiki/Bash_(Unix_shell)) will be used 
+> throughout the workshop.
+> The default for new LHCb computing accounts is called `tcsh` 
+> (“tee-cee-shell”), however, which has subtly different ways of doing things 
+> in comparison with Bash.
+>
+> It is recommended to change your default shell to Bash, which is much more 
+> widely used than `tcsh` and also supported by LHCb, by visiting the your 
+> [CERN account page](https://account.cern.ch), then clicking “Resources and 
+> services”, then “List services”, “LXPLUS and Linux”, “Settings”, then change 
+> “Unix shell” to `/bin/bash`, and click “Save Selection”.
+>
+> If you don't want to change your default shell, just execute the `bash` 
+> command when you login to lxplus.
+
+
 > ## Windows-specific Instructions {.callout}
 >
 > On Windows, some additional steps are required before you can connect via 


### PR DESCRIPTION
The default LHCb shell is `tcsh`. This PR adds instructions to the prerequisites lesson for changing the default from `tcsh` to `bash`.
