### PR TITLE
Fixed the doxygen link to the LoKi Cuts namespace.

### DIFF
--- a/06-loki-functors.md
+++ b/06-loki-functors.md
@@ -16,7 +16,7 @@ Internally, functors are implemented as C++ classes that take an object of type 
 They can be used both in C++ and in python code, and can be combined with each other using logical operations.
 
 According to `TYPE2` there are 3 types of functors:
- 
+
  - *Functions*, which return `double`.
  - *Predicates*, which return a `bool`.
  - *Streamers*, which return a `std::vector` of some other type `TYPE3`.
@@ -25,9 +25,9 @@ When filling tuples, the most used functors are functions, while predicates are 
 
 According to `TYPE1`, there are many types of functors, the most important of which are (you can find a full list in the [LoKi FAQ](https://twiki.cern.ch/twiki/bin/view/LHCb/FAQ/LoKiFAQ#How_to_code_own_LoKi_functor)):
 
- - *Particle functors*, which take `LHCb::Particle*` as input. 
+ - *Particle functors*, which take `LHCb::Particle*` as input.
  - *Vertex functors*, which take `LHCb::VertexBase*` as input.
- - *MC particle functors*, which take `LHCb::MCParticle*` as input. 
+ - *MC particle functors*, which take `LHCb::MCParticle*` as input.
  - *MC vertex functors*, which take `LHCb::MCVertex*` as input.
  - *Array particle functors*, which take a `LoKi::Range_` (an array of particles) as input.
  - *Track functors*, which take `LHCb::Track` as input.
@@ -70,7 +70,7 @@ from LoKiPhys.decorators import VCHI2
 print VCHI2(cand.endVertex())
 ```
 
-This is inconvenient when running from python options, since in that case we don't have any way of calling the `endVertex` method. 
+This is inconvenient when running from python options, since in that case we don't have any way of calling the `endVertex` method.
 In that case, we can use the `VFASPF` adaptor functor, which allows to use vertex functors as if they were particle functors (note how the functor is built by combining two functors)
 
 ```python
@@ -93,7 +93,7 @@ Given that this is a very common operation, we have the possibility of using, in
 Some functors also end with the suffix `DV`, which means they can only be used in the `DaVinci` context.
 
 > ## Finding LoKi functors {.callout}
-> The full list of defined LoKi functors can be found in the `LoKi::Cuts` namespace in the [doxygen](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/latest/doxygen/d7/dae/namespace_lo_ki_1_1_cuts.html).
+> The full list of defined LoKi functors can be found in the `LoKi::Cuts` namespace in the [doxygen](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/latest_doxygen/d7/dae/namespace_lo_ki_1_1_cuts.html).
 > They are quite well documented with examples on how to use them.
 > The list can be overwhelming, so it's also worth checking a more curated selection of functors in the TWiki, [here](https://twiki.cern.ch/twiki/bin/view/LHCb/LoKiHybridFilters) and [here](https://twiki.cern.ch/twiki/bin/view/LHCb/LoKiParticleFunctions).
 
@@ -192,5 +192,3 @@ this second option will be discussed in the [TupleTools and branches lesson](12-
     monitor_p_components_sum = monitor(p_components_sum)
     monitor_p_components_sum(cand)
     ```
-
-

--- a/12-add-tupletools.md
+++ b/12-add-tupletools.md
@@ -13,7 +13,7 @@ minutes: 15
 > * Find useful TupleTools
 > * Learn how to use LoKi functors in a DecayTreeTuple
 
-Usually, the default information stored by `DecayTreeTuple` as shown in our [minimal DaVinci job](08-minimal-dv-job.html) is not enough for physics analysis. 
+Usually, the default information stored by `DecayTreeTuple` as shown in our [minimal DaVinci job](08-minimal-dv-job.html) is not enough for physics analysis.
 Fortunately, most of the information we need can be added by adding C++ tools (known as `TupleTools`) to `dtt`;
 there is an extensive library of these, some of which will be briefly discussed during the lesson.
 
@@ -47,7 +47,7 @@ For example, if we wanted the information of the PV associated to our particle, 
 dtt.addTupleTool('TupleToolPrimaries')
 ```
 
-The way the `DecayTreeTuple.Decay` is written in in our [minimal DaVinci job](08-minimal-dv-job.html), 
+The way the `DecayTreeTuple.Decay` is written in in our [minimal DaVinci job](08-minimal-dv-job.html),
 
 ```python
 dtt.Decay = '[D*(2010)+ -> (D0 -> K- pi+) pi+]CC'
@@ -110,7 +110,7 @@ The updated options can be found [here](./code/12-add-tupletools/ntuple_options.
 > ## Test your ntuple {.challenge}
 > Run the options in the same way as in the [minimal DaVinci job](08-minimal-dv-job.html) lesson.
 > You will obtain a `DVntuple.root` file, which we can open and inspect with `ROOT`'s `TBrowser`:
-> 
+>
 > ```
 > $ root DVntuple.root
 > root [0]
@@ -118,7 +118,7 @@ The updated options can be found [here](./code/12-add-tupletools/ntuple_options.
 > root [1] TBrowser *b = new TBrowser()
 > root [2]
 > ```
-> 
+>
 > Try to locate the branches we have added, which are placed in the `TupleDstToD0pi_D0ToKpi/DecayTree`, and plot some distributions by double-clicking the leaves.
 
 Picking up with the [LoKi functors lesson](06-loki-functors.html), let's store some specific bits of information discussed there in our ntuple.
@@ -168,5 +168,5 @@ To add LoKi-based leaves to the tree, we need to use the `LoKi::Hybrid::TupleToo
 In the code snippets specified above (available [here](code/12-add-tupletools/ntuple_options_loki.py)), you can see that the `NINTREE` functor counts the number of particles that pass the specified criteria. While this is not very useful for ntuple-building (we can always do it offline), it's a very powerful functor to use when building decay selections.
 
 > ## Getting more practice {.challenge}
-> In the `LoKi::Hybrid::TupleTool`we've used some  functors that have not been described previously. Find out what they do in the [doxygen](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/latest/doxygen/d7/dae/namespace_lo_ki_1_1_cuts.html).
+> In the `LoKi::Hybrid::TupleTool`we've used some  functors that have not been described previously. Find out what they do in the [doxygen](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/latest_doxygen/d7/dae/namespace_lo_ki_1_1_cuts.html).
 > To check `SUMTREE` and `CHILD`, run the code above and check that the `Dstar_max_pt` and `Dstar_max_pt_preambulo` and the `Dstar_mass_D0` and `D0_mass` branches have exactly the same values.


### PR DESCRIPTION
The link to the LoKi Cuts namespace doxygen was somehow sometimes broken (I remember Albert trying to access it during the LoKi functors lesson). So I replaced the links in lesson 06 and 12. 
