### PR TITLE
Replaced MM functor with M functor

### DIFF
--- a/12-add-tupletools.md
+++ b/12-add-tupletools.md
@@ -144,8 +144,8 @@ To add LoKi-based leaves to the tree, we need to use the `LoKi::Hybrid::TupleToo
   - The `Variables` property, consisting of a `dict` of (variable name, LoKi functor) pairs. In here, LoKi functors can be used, as well as any variable we may have defined in the `Preambulo`:
     ```python
     dstar_hybrid.Variables = {
-        'mass': 'MM',
-        'mass_D0': 'CHILD(MM, 1)',
+        'mass': 'M',
+        'mass_D0': 'CHILD(M, 1)',
         'pt': 'PT',
         'dz': 'DZ',
         'dira': 'BPVDIRA',
@@ -155,7 +155,7 @@ To add LoKi-based leaves to the tree, we need to use the `LoKi::Hybrid::TupleToo
         'n_highpt_tracks': 'NINTREE(ISBASIC & HASTRACK & (PT > 1500*MeV))'
     }
     d0_hybrid.Variables = {
-        'mass': 'MM',
+        'mass': 'M',
         'pt': 'PT',
         'dira': 'BPVDIRA',
         'vtx_chi2': 'VFASPF(VCHI2)',

--- a/code/12-add-tupletools/ntuple_options_loki.py
+++ b/code/12-add-tupletools/ntuple_options_loki.py
@@ -35,8 +35,8 @@ dstar_hybrid.Preambulo = preamble
 d0_hybrid.Preambulo = preamble
 
 dstar_hybrid.Variables = {
-    'mass': 'MM',
-    'mass_D0': 'CHILD(MM, 1)',
+    'mass': 'M',
+    'mass_D0': 'CHILD(M, 1)',
     'pt': 'PT',
     'dz': 'DZ',
     'dira': 'BPVDIRA',
@@ -45,7 +45,7 @@ dstar_hybrid.Variables = {
     'n_highpt_tracks': 'NINTREE(ISBASIC & HASTRACK & (PT > 1500*MeV))'
 }
 d0_hybrid.Variables = {
-    'mass': 'MM',
+    'mass': 'M',
     'pt': 'PT',
     'dira': 'BPVDIRA',
     'vtx_chi2': 'VFASPF(VCHI2)',


### PR DESCRIPTION
We were told during the lesson that the MM mass gives the combined mass without any topological constraints and that we should thus use the M mass. 

I suppose this translates to the functors? The twiki is not very clear here. In this case, we should be using the M functors instead of the MM functors. I tried to replace them accordingly in this lesson
