### PR TITLE
Pin commonmark version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-CommonMark
+CommonMark==0.5.4
 pandocfilters
 PyYAML
 pep8


### PR DESCRIPTION
Fixes #165 

Our checking code breaks with a more recent version of CommonMark. Bandaid solution is to pin the version. In the long term we should probably migrate to the new version.
