### PR TITLE
Added reference to LHCb Q&A

### DIFF
--- a/14-asking-questions.md
+++ b/14-asking-questions.md
@@ -27,7 +27,8 @@ will depend very much on the way you ask your question.
 
 > ## [LHCb Q&A](https://lhcbqa.web.cern.ch/lhcbqa/) {.callout}
 >
-> An experimental alternative to he mailing lists is the [LHCb Questions and Answers website](https://lhcbqa.web.cern.ch/lhcbqa/).
+> An experimental alternative to the mailing lists is the 
+> [LHCb Questions and Answers website](https://lhcbqa.web.cern.ch/lhcbqa/).
 > It works like [Stack overflow](https://stackoverflow.com/), but focuses on LHCb-specific questions.
 > You can post your question there and you should usually receive an answer within a few hours or days.
 

--- a/14-asking-questions.md
+++ b/14-asking-questions.md
@@ -25,6 +25,12 @@ will depend very much on the way you ask your question.
 > more general questions [Stack overflow](http://stackoverflow.com/) and
 > [google](http://google.com) are good starting places.
 
+> ## [LHCb Q&A](https://lhcbqa.web.cern.ch/lhcbqa/) {.callout}
+>
+> An experimental alternative to he mailing lists is the [LHCb Questions and Answers website](https://lhcbqa.web.cern.ch/lhcbqa/).
+> It works like [Stack overflow](https://stackoverflow.com/), but focuses on LHCb-specific questions.
+> You can post your question there and you should usually receive an answer within a few hours or days.
+
 The title/subject is the first thing people will see of your
 question. If it is not interesting, they will not read the rest.
 If you are struggling with a good title, write it last! Having


### PR DESCRIPTION
As discussed in this issue https://github.com/lhcb/starterkit/issues/21 (which was unfortunately posted to the wrong projet.)

I added the reference after the mention of the mailing lists since LHCb Q&A is supposed to at least partially replace the mailing lists.So this seemed like the most natural place to add this.
If you think this is too prominently placed, I can of course change it.
