### PR TITLE
Typo fixes

### DIFF
--- a/04-files-from-grid.md
+++ b/04-files-from-grid.md
@@ -53,7 +53,7 @@ Again this will take a while but afterwards you should have a file called `00035
 > As a workaround, the file is also available on EOS, and can be downloaded to
 > your current directory with the following command:
 > ```bash
-> $ xrdcp root://eoslhcb.cern.ch//eos/lhcb/user/a/apearce/Starterkit/Nov2015/00035742_00000001_1.allstreams.dst
+> $ xrdcp root://eoslhcb.cern.ch//eos/lhcb/user/a/apearce/Starterkit/Nov2015/00035742_00000001_1.allstreams.dst .
 > ```
 
 Since these files tend to be quite large, you might want to use your AFS work 

--- a/05-interactive-dst.md
+++ b/05-interactive-dst.md
@@ -140,7 +140,7 @@ Add this to your script and restart `ipython` as before.
 > if you want to get it right for data and simulation. Checking that
 > `/Event/Rec/Header` exists is a safe bet in simulation and data if
 > your file has been processed by `Brunel` (the event reconstruction
-> software. It might not work in other cases.
+> software). It might not work in other cases.
 
 Using the name of our stripping line we can now advance through the
 DST until we reach an event which contains a candidate:

--- a/07-dataflow.md
+++ b/07-dataflow.md
@@ -107,7 +107,7 @@ each application has manipulated the data you want to use.
 > the disadvantages?
 
 With the exception of a few specific studies, it is only the DaVinci 
-application that is ran by users, everything else is run ‘centrally’ either on 
+application that is run by users, everything else is run ‘centrally’ either on 
 the computing farm next to the detector or on the Grid.
 
 The reconstruction, Brunel, is rarely performed as it is very computationally 


### PR DESCRIPTION
Adding a few minor typo fixes, including a missing destination in a copy command and cosmetic typos.
