### PR TITLE
Update lessons to use DaVinci v41r2

### DIFF
--- a/code/davinci-grid/first-job.py
+++ b/code/davinci-grid/first-job.py
@@ -1,4 +1,4 @@
-j = Job(application=DaVinci(version='v40r2'))
+j = Job(application=DaVinci(version='v41r2'))
 j.backend = Dirac()
 j.name = 'First ganga job'
 j.inputdata = j.application.readInputData((

--- a/code/split-jobs/first-job.py
+++ b/code/split-jobs/first-job.py
@@ -1,4 +1,4 @@
-j = Job(application=DaVinci(version='v40r2'))
+j = Job(application=DaVinci(version='v41r2'))
 j.backend = Dirac()
 j.name = 'First ganga job'
 j.inputdata = j.application.readInputData((

--- a/davinci-grid.md
+++ b/davinci-grid.md
@@ -30,7 +30,7 @@ to some special commands provided by `ganga`.
 To create your first `ganga` job type the following:
 
 ```python
-j = Job(application=DaVinci(version='v40r2'))
+j = Job(application=DaVinci(version='v41r2'))
 j.backend = Dirac()
 j.name = 'First ganga job'
 j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
@@ -47,7 +47,7 @@ use to configure the job.
 
 Now you have created your first job, however it has not started
 running yet. To submit it type `j.submit()`. Now `ganga` will do the
-equivalent of `SetupProject DaVinci v40r2`, prepare your job and then
+equivalent of `SetupProject DaVinci v41r2`, prepare your job and then
 ship it off to the grid.
 
 While it runs, let's submit an identical job via slightly different
@@ -58,7 +58,7 @@ lines that define a job in a file and simply run that.
 Place the following in a file called [`first-job.py`](code/davinci-grid/first-job.py):
 
 ```python
-j = Job(application=DaVinci(version='v40r2'))
+j = Job(application=DaVinci(version='v41r2'))
 j.backend = Dirac()
 j.name = 'First ganga job'
 j.inputdata = j.application.readInputData('data/MC_2012_27163003_Beam4000GeV2012MagDownNu2.5Pythia8_Sim08e_Digi13_Trig0x409f0045_Reco14a_Stripping20NoPrescalingFlagged_ALLSTREAMS.DST.py')
@@ -123,7 +123,7 @@ To look at the `root` file produced by the job start a new terminal, and
 type:
 
 ```bash
-$ lb-run DaVinci v40r2 $SHELL
+$ lb-run DaVinci v41r2 $SHELL
 $ root -l path/to/the/job/output
 ```
 

--- a/davinci.md
+++ b/davinci.md
@@ -58,26 +58,26 @@ One of the most important ones is *DaVinci*, which provides lots of *Algorithms*
 
 You can run DaVinci using the following command:
 ```bash
-lb-run DaVinci v40r2 gaudirun.py
+lb-run DaVinci v41r2 gaudirun.py
 ```
 
-This will run the `gaudirun.py` command using version v40r2 of DaVinci.
+This will run the `gaudirun.py` command using version v41r2 of DaVinci.
 `gaudirun.py` is a script that sets up the EventLoop.
 You should get the following output:
 
 ```
 # setting LC_ALL to "C"
-ApplicationMgr    SUCCESS 
+ApplicationMgr    SUCCESS
 ====================================================================================================================================
-                                                   Welcome to DaVinci version v40r2
-                                          running on lxplus0077.cern.ch on Thu May 28 11:09:31 2015
+                                                   Welcome to DaVinci version v41r2
+                                          running on lxplus0107.cern.ch on Tue Oct 25 17:26:01 2016
 ====================================================================================================================================
 ApplicationMgr       INFO Application Manager Configured successfully
 HistogramPersis...WARNING Histograms saving not required.
 ApplicationMgr       INFO Application Manager Initialized successfully
 ApplicationMgr       INFO Application Manager Started successfully
 EventSelector        INFO End of event input reached.
-EventLoopMgr         INFO No more events in event selection 
+EventLoopMgr         INFO No more events in event selection
 ApplicationMgr       INFO Application Manager Stopped successfully
 EventLoopMgr         INFO Histograms converted successfully according to request.
 ToolSvc              INFO Removing all tools created by ToolSvc
@@ -89,7 +89,7 @@ During this run, DaVinci didn't do anything: We didn't specify any algorithms to
 Usually, you will write an option file (e.g. `options.py`) and specify it as an argument to `gaudirun.py`:
 
 ```bash
-lb-run DaVinci v40r2 gaudirun.py options.py
+lb-run DaVinci v41r2 gaudirun.py options.py
 ```
 
 An `option.py` is just a regular Python script that specifies how to set things up in the software.
@@ -97,7 +97,7 @@ Many of the following lessons will teach you how to do something with DaVinci by
 You can use the above command to test it.
 You can also specify several option files like this:
 ```bash
-lb-run DaVinci v40r2 gaudirun.py options1.py options2.py
+lb-run DaVinci v41r2 gaudirun.py options1.py options2.py
 ```
 They will then both be used to set up DaVinci.
 
@@ -108,7 +108,7 @@ lb-run --list DaVinci
 Do you want to start a shell that already contains the LHCb environment, so you don't have to use `lb-run`?
 Execute
 ```bash
-lb-run DaVinci v40r2 $SHELL
+lb-run DaVinci v41r2 $SHELL
 ```
 A simple `gaudirun.py` should work as well now.
 Typing `exit` will close the shell and leave the LHCb environment behind.
@@ -117,9 +117,9 @@ Typing `exit` will close the shell and leave the LHCb environment behind.
 > When reading through other tutorials, you will come across `SetupProject`.
 > This is an older way of setting up a shell that is configured to run LHCb software.
 > `lb-run` is the new way of doing things and has some nice benefits over `SetupProject`.
-> For most purposes, `SetupProject DaVinci v40r2` is equivalent to
+> For most purposes, `SetupProject DaVinci v41r2` is equivalent to
 > ```bash
-> lb-run DaVinci v40r2 $SHELL
+> lb-run DaVinci v41r2 $SHELL
 > ```
 
 

--- a/interactive-dst.md
+++ b/interactive-dst.md
@@ -51,7 +51,7 @@ Place this into a file called `first.py` and run the following
 command in a new terminal:
 
 ```bash
-$ lb-run DaVinci v40r2 ipython -i first.py 00035742_00000002_1.allstreams.dst
+$ lb-run DaVinci v41r2 ipython -i first.py 00035742_00000002_1.allstreams.dst
 ```
 
 This will open the DST and print out some of the TES locations
@@ -164,7 +164,7 @@ one with:
 print cands[0]
 ```
 
-Which will print out some information about the [Particle](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/v40r2/doxygen/d0/d13/class_l_h_cb_1_1_particle.html#details). In our case a D*. You can access its daughters with
+Which will print out some information about the [Particle](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/v41r2/doxygen/d0/d13/class_l_h_cb_1_1_particle.html#details). In our case a D*. You can access its daughters with
 `cands[0].daughtersVector()[0]` and `cands[0].daughtersVector()[1]`,
 which will be a D0 and a pion.
 

--- a/lhcb-dev.md
+++ b/lhcb-dev.md
@@ -55,37 +55,33 @@ Your new development environment won't be very useful without any software to mo
 So why not check out out one of the existing LHCb packages, which are stored in the LHCb SVN repository?
 
 Let's assume you have already used `lb-dev` to set up your development environment and you are currently inside it.
-In order to obtain the source code of the package you want to work on, use `getpack`.
-This is an LHCb-aware wrapper around SVN.
+In order to obtain the source code of the package you want to work on, use the [Git4LHCb](https://twiki.cern.ch/twiki/bin/view/LHCb/Git4LHCb) scripts.
+These are a set of aliases, starting with `git lb-`, that are designed to make developing LHCb software easier.
 For example, if you want to write a custom stripping selection, execute the following in the `DaVinciDev` directory:
 
 ```bash
-getpack Phys/StrippingSelections head
+git lb-use Stripping
+git lb-checkout Stripping/master Phys/StrippingSelections
+make configure
 ```
 
-Under the hood, `getpack` will `svn checkout` (≈ `git clone`) the corresponding SVN repository.
-The first argument to `getpack` is the name of the package you want to checkout, while the second argument allows you to choose a specific branch.
-`head` is usually the one one that contains the newest development changes and the one you should commit new changes to.
+Under the hood, `git lb-use` will add the [`Stripping`](https://gitlab.cern.ch/lhcb/Stripping) repository as a remote in git.
+`git lb-checkout` will then perform a partial checkout of the master branch of the Stripping repository, only adding the files under [`Phys/StrippingSelections`](https://gitlab.cern.ch/lhcb/Stripping/tree/master/Phys/StrippingSelections).
 
-You can now modify the `StrippingSelections` package and run `make` to build it with your changes.
+You can now modify the `StrippingSelections` package and run `make purge && make` to build it with your changes.
 You can test your changes with the `./run` script.
 It works similar to `lb-run`, without the need to specify a package and version:
 ```bash
 ./run gaudirun.py options.py
 ```
 
-> ## What if getpack asks for my password 1000 times? {.callout}
-> `getpack` might ask you for your password several times.
+> ## What if git asks for my password 1000 times? {.callout}
+> `git` might ask you for your password several times.
 > To avoid this, you can create a kerberos token with
 > ```
-> kinit
+> kinit $USER@CERN.CH
 > ```
-> You will have to enter your password once, and further password prompts will be skipped
-> 
-> Alternatively, you can perform an anonymous checkout:
-> ```
-> getpack -p anonymous Phys/StrippingSelections
-> ```
+> You will have to enter your password once, and further password prompts will be skipped.
 
 If you just want to take a look at a source file, without checking it out, you can comfortably access the repository through two different web UIs.
 

--- a/lhcb-dev.md
+++ b/lhcb-dev.md
@@ -16,7 +16,7 @@ This lesson introduces you to two commands:
 If you want to make changes to a software package, you will need to set up a development environment. `lb-dev` is your friend here:
 
 ```bash
-lb-dev --name DaVinciDev DaVinci v40r2
+lb-dev --name DaVinciDev DaVinci v41r2
 ```
 
 The output should look similar to this:
@@ -27,20 +27,20 @@ Successfully created the local project DaVinciDev in .
 To start working:
 
   > cd ./DaVinciDev
-  > getpack MyPackage vXrY
+  > git lb-use DaVinci
+  > git lb-checkout DaVinci/vXrY MyPackage
 
 then
 
   > make
   > make test
-  > make QMTestSummary
 
-and optionally
+and optionally (CMake only)
 
   > make install
 
-You can customize the configuration by editing the files 'CMakeLists.txt'
-(see http://cern.ch/gaudi/CMake for details).
+You can customize the configuration by editing the files 'build.conf' and
+'CMakeLists.txt' (see http://cern.ch/gaudi/CMake for details).
 ```
 
 Follow those instructions and once you've compiled your software run
@@ -102,7 +102,7 @@ There is a page for each project, lists of projects can be found here:
 
 Another useful tool available on lxplus machines is `Lbglimpse`. It allows you to search for a given string in the source code of LHCb software.
 ```bash
-Lbglimpse "PVRefitter" DaVinci v40r2
+Lbglimpse "PVRefitter" DaVinci v41r2
 ```
 It works with every LHCb project and released version.
 

--- a/minimal-dv-job.md
+++ b/minimal-dv-job.md
@@ -85,7 +85,7 @@ what type of data is being used, what algorithms to run over the events, and so
 on.
 
 There are [many configuration 
-attributes](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/v40r2/doxygen/py/dc/d2f/class_da_vinci_1_1_configuration_1_1_da_vinci.html#ac788f6a80f5f61d47056debe7b86ca71) 
+attributes](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/v41r2/doxygen/py/dc/d2f/class_da_vinci_1_1_configuration_1_1_da_vinci.html#ac788f6a80f5f61d47056debe7b86ca71) 
 defined on the `DaVinci` object, but we will only set the ones that are 
 necessary for us.
 
@@ -160,7 +160,7 @@ In the same folder as your options file `ntuple_options.py` and your DST file
 ending in `.dst`, there's just a single command you need run on `lxplus`.
 
 ```shell
-$ lb-run DaVinci v40r2 gaudirun.py ntuple_options.py
+$ lb-run DaVinci v41r2 gaudirun.py ntuple_options.py
 ```
 
 The full options file we've created, `ntuple_options.py`, is [available 


### PR DESCRIPTION
This PR updates the lessons to use DaVinci v41r2 and tested all the relevant steps, except those in [10-davinci-grid.md](https://github.com/lhcb/first-analysis-steps/compare/master...chrisburr:update-davinci-v41r2#diff-ce81614c18dddc563467dbcc36011cc7). I've also updated 15-lhcb-dev.md to use `git lb-.*` instead of `getpack`.

Resolves #174.
