### PR TITLE
Remove _MM and slightly change DecayTreeFitter lesson

### DIFF
--- a/add-tupletools.md
+++ b/add-tupletools.md
@@ -99,7 +99,7 @@ The usage of `Branches` is very important (and strongly encouraged) to keep the 
 > ## Where to find TupleTools {.callout}
 > One of the most difficult things is to know which tool we need to add to our `DecayTreeTuple` in order to get the information we want.
 > For this, it is necessary to know where to find `TupleTools` and their code.
-> `TupleTools` are spread in 9 packages under `Analysis/Phys` (see the head of `svn` [here](https://svnweb.cern.ch/trac/lhcb/browser/Analysis/trunk/Phys)), all starting with the prefix `DecayTreeTuple`, according to the type of information they fill in our ntuple:
+> `TupleTools` are spread in 9 packages under `Analysis/Phys` (see the master branch in `git` [here](https://gitlab.cern.ch/lhcb/Analysis/tree/master/Phys)), all starting with the prefix `DecayTreeTuple`, according to the type of information they fill in our ntuple:
 >
 > - `DecayTreeTuple` for the more general tools.
 > - `DecayTreeTupleANNPID` for the NeuralNet-based PID tools.
@@ -114,7 +114,7 @@ The usage of `Branches` is very important (and strongly encouraged) to keep the 
 > The `TupleTools` are placed in the `src` folder within each package and it's usually easy to get what they do just by looking at their name.
 > However, the best way to know what a tool does is check its documentation, either by opening its `.h` file or be searching for it in the latest [`doxygen`](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/latest/doxygen/index.html).
 > Most tools are very well documented and will also inform you of their configuration options.
-> As an example, to get the information on the `TupleToolTrackInfo` we used before we could either check its [source code](https://svnweb.cern.ch/trac/lhcb/browser/Analysis/trunk/Phys/DecayTreeTupleReco/src/TupleToolTrackInfo.h) or its [web documentation](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/analysis/releases/latest/doxygen/da/ddd/class_tuple_tool_track_info.html).
+> As an example, to get the information on the `TupleToolTrackInfo` we used before we could either check its [source code](https://gitlab.cern.ch/lhcb/Analysis/blob/master/Phys/DecayTreeTupleReco/src/TupleToolTrackInfo.h) or its [web documentation](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/analysis/releases/latest/doxygen/da/ddd/class_tuple_tool_track_info.html).
 > In case we need more information or need to know *exactly* what the code does, the `fill` method is the one we need to look at.
 >
 > As a shortcut, the list of tupletools can also be found in doxygen at the top of the pages for the [`IParticleTupleTool`](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/latest/doxygen/d1/d77/class_i_particle_tuple_tool.html) and the [`IEventTupleTool`](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/releases/latest/doxygen/d7/d5c/class_i_event_tuple_tool.html) interfaces (depending on whether they fill information about specific particles or the event in general).

--- a/decay-tree-fitter.md
+++ b/decay-tree-fitter.md
@@ -47,7 +47,7 @@ When using the `DecayTreeFitter` in a `DecayTreeTuple`, all the variables create
 If the daughters are not stable particles and decay further, the daughters of the daughters have no new variables associated to them by default.
 Since in many cases this information might be useful, there is an option to store the information from those tracks
 ```python
-dtt.Dstar.ConsD.UpdateDaughters = Truedecay-tree-fitter.md
+dtt.Dstar.ConsD.UpdateDaughters = True
 ```
 
 > ## DecayTreeFitter and LoKi functors {.callout}

--- a/decay-tree-fitter.md
+++ b/decay-tree-fitter.md
@@ -68,7 +68,7 @@ Plotting the raw mass of the D* (without the fit) `Dstar_M` you should see a bro
 <img src="./img/DstarRaw.png" alt="Dstar raw" style="width: 500px;"/>
 
 > ## Which mass variable to use {.callout}
-> In many ntuples you also find a mass variable called `_MM`. This confusingly refers to measured mass. However, it is usually better to use `_M`. `_MM` is the sum of the 4-momenta of the final state particles at the fitted vertex position, but not the result of the actual vertex fit.
+> In many ntuples you also find a mass variable called `_MM`. This confusingly refers to measured mass. However, it is usually better to use `_M`. `_MM` is the sum of the 4-momenta of the final state particles extrapolated back to the fitted vertex position, but not the result of the actual vertex fit.
 
 
 Now let us look at the refitted mass of the D*, with the D0 constrained to its nominal mass. It is stored in the variable `Dstar_ConsD_M`. If you plot this you will note that some values are unphysical. So, let's restrict the range we look at to something that makes sense.

--- a/decay-tree-fitter.md
+++ b/decay-tree-fitter.md
@@ -47,7 +47,7 @@ When using the `DecayTreeFitter` in a `DecayTreeTuple`, all the variables create
 If the daughters are not stable particles and decay further, the daughters of the daughters have no new variables associated to them by default.
 Since in many cases this information might be useful, there is an option to store the information from those tracks
 ```python
-dtt.Dstar.ConsD.UpdateDaughters = True
+dtt.Dstar.ConsD.UpdateDaughters = Truedecay-tree-fitter.md
 ```
 
 > ## DecayTreeFitter and LoKi functors {.callout}
@@ -63,9 +63,13 @@ root -l DVntuple.root
 TupleDstToD0pi_D0ToKpi->cd()
 DecayTree->StartViewer()
 ```
-Plotting the raw mass of the D* (without the fit) `Dstar_MM` you should see a broad signal around 2 GeV:
+Plotting the raw mass of the D* (without the fit) `Dstar_M` you should see a broad signal around 2 GeV:
 
 <img src="./img/DstarRaw.png" alt="Dstar raw" style="width: 500px;"/>
+
+> ## Which mass variable to use {.callout}
+> In many ntuples you also find a mass variable called `_MM`. This confusingly refers to measured mass. However, it is usually better to use `_M`. `_MM` is the sum of the 4-momenta of the final state particles at the fitted vertex position, but not the result of the actual vertex fit.
+
 
 Now let us look at the refitted mass of the D*, with the D0 constrained to its nominal mass. It is stored in the variable `Dstar_ConsD_M`. If you plot this you will note that some values are unphysical. So, let's restrict the range we look at to something that makes sense.
 

--- a/decay-tree-fitter.md
+++ b/decay-tree-fitter.md
@@ -51,7 +51,7 @@ dtt.Dstar.ConsD.UpdateDaughters = True
 ```
 
 > ## DecayTreeFitter and LoKi functors {.callout}
-> Alternatively, many of the operations described above can done by using the `DecayTreeFitter` via LoKi functors, see the [second-analysis-steps](https://lhcb.github.io/second-analysis-steps/) for details.
+> Alternatively, many of the operations described above can done by using the `DecayTreeFitter` via LoKi functors, see the [DaVinci tutorial](https://twiki.cern.ch/twiki/bin/view/LHCb/DaVinciTutorial9b) for details.
 
 > ## Which constraints to apply {.callout}
 > It is important to be aware what assumptions you bake into your ntuple. For example, after you require the vertex constraint you must be careful if using the `IPCHI2_OWNPV`, since the particle you are looking at is *forced* to point to the PV. Which constraints make most sense for you depends on the questions you want to ask in your analysis, so ask your supervisor/working group in case of doubt.

--- a/loki-functors.md
+++ b/loki-functors.md
@@ -78,7 +78,7 @@ p_components_sum(cand)
 > ## Does it make sense? {.challenge}
 > Retrieve the momentum magnitude $p$ and see if you can get the same answer 
 > with the `PX`, `PY`, `PZ` functors.
-> Also compute the invariant mass $m$ and see if it matches what the `MM` 
+> Also compute the invariant mass $m$ and see if it matches what the `M` 
 > functor returned.
 
 
@@ -223,9 +223,9 @@ Therefore, to access the $p_{\text{T}}$ of the $D^{0}$ we have 2 options.
 ```python
 from LoKiPhys.decorators import CHILD
 # Option 1
-mass = MM(cand.daughtersVector()[0])
+mass = M(cand.daughtersVector()[0])
 # Option 2
-mass_child = CHILD(MM, 1)(cand)
+mass_child = CHILD(M, 1)(cand)
 # Do they agree?
 mass == mass_child
 ```
@@ -247,8 +247,8 @@ It helps writing CPU-efficient functors and thus is very important when building
 
 ```python
 from LoKiCore.functions import in_range
-in_range(2000, MM, 2014)(cand)
-in_range(1860, CHILD(MM, 1), 1870)(cand)
+in_range(2000, M, 2014)(cand)
+in_range(1860, CHILD(M, 1), 1870)(cand)
 ```
 
 Additionally, LoKi functors can be used directly inside our `DaVinci` jobs to store specific bits of information in our ntuples without the need for a complicated C++-based algorithms.

--- a/loki-functors.md
+++ b/loki-functors.md
@@ -52,9 +52,9 @@ We can now try to get very simple properties of the $D^{*+}$ candidate, such as
 its transverse momentum and measured mass.
 
 ```python
-from LoKiPhys.decorators import PT, MM
+from LoKiPhys.decorators import PT, M
 print PT(cand)
-print MM(cand)
+print M(cand)
 ```
 
 You will see an error when loading the functors:


### PR DESCRIPTION
- I changed the link to second analysis steps to a DaVinci tutorial as I did not find a topic about DecayTreeFitter
- Removed the use of _MM, the graphic still needs to be adapted. Added a callout box, trying to explain the difference.